### PR TITLE
Disable msvc sccache

### DIFF
--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -55,9 +55,10 @@ jobs:
       with:
         submodules: true
 
-    - name: Set Github runner's env (CXX=${{ matrix.cmake.compiler }}) 
-      env:
-        CXX=${{ matrix.cmake.compiler }}
+    - name: Set Github runner's env (CXX=${{ matrix.cmake.compiler }})
+      shell: cmd    
+      run: |
+        echo "CXX=${{ matrix.cmake.compiler }}" >> $GITHUB_ENV
 
     - name: Install conan package manager
       id: conan2
@@ -92,14 +93,12 @@ jobs:
         rem dir /s /b C:\\Users\\runneradmin\\.conan2
         echo $HOME
 
-    - name: Conditionally set CMAKE_CXX_COMPILER_LAUNCHER
-      # Run into trouble using Conan-CMake (only Debug, Release success) and sccache on MSVC
-      if: ${{ matrix.cmake.configure_preset != "msvc" }}
-      env:
-        CMAKE_CXX_COMPILER_LAUNCHER: "sccache"         
-                
     - name: CMake configuration
       shell: cmd
+      env:
+        # Did run into trouble with Conan-CMake provider and sccache on build of
+        # Debug build (Release works fine) ...
+        CMAKE_CXX_COMPILER_LAUNCHER: if ${{ matrix.cmake.configure_preset != 'msvc' && 'sccache' || '' }}
       run: |
         call "${{ matrix.cmake.vcvars }}"
         cmake --preset ${{ matrix.cmake.configure_preset }}

--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -55,10 +55,9 @@ jobs:
       with:
         submodules: true
 
-    - name: Set Github runner's env (CXX=${{ matrix.cmake.compiler }})
-      shell: cmd    
-      run: |
-        echo "CXX=${{ matrix.cmake.compiler }}" >> $GITHUB_ENV
+    - name: Set Github runner's env (CXX=${{ matrix.cmake.compiler }}) 
+      env:
+        CXX=${{ matrix.cmake.compiler }}
 
     - name: Install conan package manager
       id: conan2
@@ -93,10 +92,14 @@ jobs:
         rem dir /s /b C:\\Users\\runneradmin\\.conan2
         echo $HOME
 
+    - name: Conditionally set CMAKE_CXX_COMPILER_LAUNCHER
+      # Run into trouble using Conan-CMake (only Debug, Release success) and sccache on MSVC
+      if: ${{ matrix.cmake.configure_preset != "msvc" }}
+      env:
+        CMAKE_CXX_COMPILER_LAUNCHER: "sccache"         
+                
     - name: CMake configuration
       shell: cmd
-      env:
-        CMAKE_CXX_COMPILER_LAUNCHER: "sccache"
       run: |
         call "${{ matrix.cmake.vcvars }}"
         cmake --preset ${{ matrix.cmake.configure_preset }}

--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -98,7 +98,7 @@ jobs:
       env:
         # Did run into trouble with Conan-CMake provider and sccache on build of
         # Debug build (Release works fine) ...
-        CMAKE_CXX_COMPILER_LAUNCHER: if ${{ matrix.cmake.configure_preset != 'msvc' && 'sccache' || '' }}
+        CMAKE_CXX_COMPILER_LAUNCHER: ${{ matrix.cmake.configure_preset != 'msvc' && 'sccache' || '' }}
       run: |
         call "${{ matrix.cmake.vcvars }}"
         cmake --preset ${{ matrix.cmake.configure_preset }}


### PR DESCRIPTION
Disable Mozilla sccache for MSVC build (not MSVC Clang), did run into build problems with Conan (CMake provider). Conan Release build of Catch2 works, but Debug failed - see 
Fix cmake conan #80 (CMake Windows log: https://github.com/ibis-hdl/gh-actions-test/actions/runs/12223310133/job/34094781863)

```
catch2/3.7.1: Running CMake.build()
catch2/3.7.1: RUN: cmake --build "C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build" --config Debug -- -j4
conanvcvars.bat: Activating environment Visual Studio 17 - amd64 - winsdk_version=None - vcvars_ver=14.4
[vcvarsall.bat] Environment initialized for: 'x64'
[1/108 (0.421s)] Building CXX object src\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\catch_chronometer.cpp.obj
FAILED: src/CMakeFiles/Catch2.dir/Debug/catch2/benchmark/catch_chronometer.cpp.obj 
sccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe  /nologo /TP -DCMAKE_INTDIR=\"Debug\" -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\.. -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build\generated-includes /DWIN32 /D_WINDOWS /W3 /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd /showIncludes /Fosrc\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\catch_chronometer.cpp.obj /Fdsrc\CMakeFiles\Catch2.dir\Debug\Catch2.pdb /FS -c C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\benchmark\catch_chronometer.cpp
sccache: encountered fatal error
sccache: error: failed to persist temporary file: Access is denied. (os error 5)
sccache: caused by: failed to persist temporary file: Access is denied. (os error 5)
sccache: caused by: Access is denied. (os error 5)
[2/108 (0.540s)] Building CXX object src\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\detail\catch_benchmark_function.cpp.obj
FAILED: src/CMakeFiles/Catch2.dir/Debug/catch2/benchmark/detail/catch_benchmark_function.cpp.obj 
sccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe  /nologo /TP -DCMAKE_INTDIR=\"Debug\" -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\.. -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build\generated-includes /DWIN32 /D_WINDOWS /W3 /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd /showIncludes /Fosrc\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\detail\catch_benchmark_function.cpp.obj /Fdsrc\CMakeFiles\Catch2.dir\Debug\Catch2.pdb /FS -c C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\benchmark\detail\catch_benchmark_function.cpp
C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\benchmark\detail\catch_benchmark_function.cpp: fatal error C1041: cannot open program database 'C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build\src\CMakeFiles\Catch2.dir\Debug\Catch2.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
[3/108 (0.540s)] Building CXX object src\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\detail\catch_analyse.cpp.obj
FAILED: src/CMakeFiles/Catch2.dir/Debug/catch2/benchmark/detail/catch_analyse.cpp.obj 
sccache C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1442~1.344\bin\Hostx64\x64\cl.exe  /nologo /TP -DCMAKE_INTDIR=\"Debug\" -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\.. -IC:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build\generated-includes /DWIN32 /D_WINDOWS /W3 /GR /EHsc /Zi /Ob0 /Od /RTC1 -std:c++20 -MDd /showIncludes /Fosrc\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\detail\catch_analyse.cpp.obj /Fdsrc\CMakeFiles\Catch2.dir\Debug\Catch2.pdb /FS -c C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\benchmark\detail\catch_analyse.cpp
C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\src\src\catch2\benchmark\detail\catch_analyse.cpp: fatal error C1041: cannot open program database 'C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build\src\CMakeFiles\Catch2.dir\Debug\Catch2.pdb'; if multiple CL.EXE write to the same .PDB file, please use /FS
[4/108 (1.853s)] Building CXX object src\CMakeFiles\Catch2.dir\Debug\catch2\benchmark\detail\catch_run_for_at_least.cpp.obj
ninja: build stopped: subcommand failed.

catch2/3.7.1: ERROR: 
Package '062e7655cea253a81bd3f96afc0d4be5829d9b29' build failed
catch2/3.7.1: WARN: Build folder C:\Users\runneradmin\.conan2\p\b\catch7e186cbdc646e\b\build
ERROR: catch2/3.7.1: Error in build() method, line 117
	cmake.build()
	ConanException: Error 1 while executing
CMake Error at cmake/cmake-conan/conan_provider.cmake:483 (message):
  Conan install failed='1'
Call Stack (most recent call first):
  cmake/cmake-conan/conan_provider.cmake:595 (conan_install)
  CMakeLists.txt:14 (find_package)
```